### PR TITLE
Print parts of PhpParser\Node\Name in diagram

### DIFF
--- a/lib/Printer.php
+++ b/lib/Printer.php
@@ -3,7 +3,7 @@
 namespace PHPAstVisualizer;
 
 use PhpParser\Node;
-
+use PhpParser\Node\Name;
 use phpDocumentor\GraphViz\Edge as GraphEdge;
 use phpDocumentor\GraphViz\Node as GraphNode;
 
@@ -91,6 +91,9 @@ class Printer {
                 $result[] = "{$name}: " . ($node->$name ? 'true' : 'false');
             } elseif (is_scalar($node->$name)) {
                 $result[] = "{$name}: {$node->$name}";
+            } elseif($node instanceof Name) {
+                $fullName = implode('\\', $node->parts);
+                $result[] = "name: $fullName";
             }
         }
         return $this->printNodeValue($node, ...$result);


### PR DESCRIPTION
Adds the name parts of `PhpParser\Node\Name` to the diagram output. I needed this to see what nodes the boxes refers to. Not sure it takes to much place though

### Before
![demo123](https://user-images.githubusercontent.com/3457668/148356233-8bca8478-be67-487a-ba9c-89e330701839.png)

### Now
![demo123](https://user-images.githubusercontent.com/3457668/148356258-191dbc0c-cc58-4dab-8ce4-02781890429b.png)

Example file used: https://github.com/laravel/laravel/tree/8.x/app/Models/User.php
